### PR TITLE
fix #51

### DIFF
--- a/src/parser/Parser.cpp
+++ b/src/parser/Parser.cpp
@@ -85,7 +85,8 @@ namespace Parser
     {
         if (_exitIsCalled == false)
             return (false);
-        std::regex const reg("([a-z]*)(\\s*((\\s*[a-z]+\\d*?)*)\\s*\\(([-]?\\d+(\\.\\d+)?)\\)*)?(\\s*\\;.*)?"); // new regex
+        std::regex const reg(
+            "([a-z]*)(\\s*((\\s*[a-z]+\\d*?)*)\\s*\\(([-]?\\d+(\\.\\d+)?)\\)*)?(\\s*\\;.*)?"); // new regex
         std::regex const regComment("([;].*)");
         std::smatch match;
 

--- a/src/parser/Parser.cpp
+++ b/src/parser/Parser.cpp
@@ -85,7 +85,7 @@ namespace Parser
     {
         if (_exitIsCalled == false)
             return (false);
-        std::regex const reg("([a-z]*)(\\s*(([a-z]+\\d*?)*)\\(([-]?\\d+(\\.\\d+)?)\\)*)?(\\s\\;.*)?"); // new regex
+        std::regex const reg("([a-z]*)(\\s*((\\s*[a-z]+\\d*?)*)\\s*\\(([-]?\\d+(\\.\\d+)?)\\)*)?(\\s*\\;.*)?"); // new regex
         std::regex const regComment("([;].*)");
         std::smatch match;
 


### PR DESCRIPTION
rework regex > allow many space between any 'group'
comment inline are now able to manage many space before ';'